### PR TITLE
Version 0.2.0, breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Feel free to make a PR to add your implementation.
 
 ## History
 
+**0.2.0**
+- (breaking change) The upgradeable version is not extending UUPSUpgradeable anymore, leaving the developer to decide with proxy to use. This implies that whoever is using ERC721Lockable without importing UUPSUpgradeable, now has to import it explicitly.
+
 **0.1.2**
 - Use `pragma solidity ^0.8.0;` instead of specific version
 

--- a/contracts/ERC721LockableUpgradeable.sol
+++ b/contracts/ERC721LockableUpgradeable.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
@@ -17,8 +16,7 @@ contract ERC721LockableUpgradeable is
   Initializable,
   OwnableUpgradeable,
   ERC721Upgradeable,
-  ERC721EnumerableUpgradeable,
-  UUPSUpgradeable
+  ERC721EnumerableUpgradeable
 {
   using AddressUpgradeable for address;
 
@@ -31,18 +29,18 @@ contract ERC721LockableUpgradeable is
   }
 
   /**
-     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
-     */
+   * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+   */
+  // solhint-disable-next-line
   function __ERC721Lockable_init(string memory name_, string memory symbol_) internal onlyInitializing {
     __ERC721Lockable_init_unchained(name_, symbol_);
   }
 
+  // solhint-disable-next-line
   function __ERC721Lockable_init_unchained(string memory name_, string memory symbol_) internal onlyInitializing {
     __ERC721_init(name_, symbol_);
     __Ownable_init();
   }
-
-  function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
 
   function _beforeTokenTransfer(
     address from,

--- a/contracts/mocks/ERC721LockableUpgradeableMock.sol
+++ b/contracts/mocks/ERC721LockableUpgradeableMock.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.11;
 
 // Authors: Francesco Sullo <francesco@sullo.co>
 
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "../ERC721LockableUpgradeable.sol";
 
 //import "hardhat/console.sol";
 
-contract ERC721LockableUpgradeableMock is ERC721LockableUpgradeable {
-
+contract ERC721LockableUpgradeableMock is ERC721LockableUpgradeable, UUPSUpgradeable {
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() initializer {}
 
@@ -16,4 +16,5 @@ contract ERC721LockableUpgradeableMock is ERC721LockableUpgradeable {
     __ERC721Lockable_init(name, symbol);
   }
 
+  function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/erc721lockable",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The upgradeable version is not extending UUPSUpgradeable anymore, leaving the developer to decide with proxy to use. This implies that whoever is using ERC721Lockable without importing UUPSUpgradeable, now has to import it explicitly.