### PR TITLE
Extending IERC5192

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,11 @@ pragma solidity ^0.8.4;
 // Author:
 // Francesco Sullo <francesco@sullo.co>
 
-// ERC165 interface id is 0xd8e4c296
-interface IERC721Lockable {
+// ERC165 interface id is 0x2e4e0d27
+interface IERC721Lockable is IERC5192 {
   event LockerSet(address locker);
   event LockerRemoved(address locker);
   event ForcefullyUnlocked(uint256 tokenId);
-  event Locked(uint256 tokendId);
-  event Unlocked(uint256 tokendId);
-
-  // tells if a token is locked
-  function isLocked(uint256 tokenID) external view returns (bool);
 
   // tells the address of the contract which is locking a token
   function lockerOf(uint256 tokenID) external view returns (address);
@@ -104,6 +99,9 @@ As soon as I have a moment, I will add an example here and move the testing.
 Feel free to make a PR to add your implementation.
 
 ## History
+
+**0.3.0**
+- (breaking) removed the `isLocked` function in favor of `locked`, to extend the new proposal IERC5192. As a consequence the interfaceId is changed from `0xd8e4c296` to `0x2e4e0d27`
 
 **0.2.0**
 - (breaking change) The upgradeable version is not extending UUPSUpgradeable anymore, leaving the developer to decide with proxy to use. This implies that whoever is using ERC721Lockable without importing UUPSUpgradeable, now has to import it explicitly.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Feel free to make a PR to add your implementation.
 ## History
 
 **0.3.0**
-- (breaking) removed the `isLocked` function in favor of `locked`, to extend the new proposal IERC5192. As a consequence the interfaceId is changed from `0xd8e4c296` to `0x2e4e0d27`
+- (breaking) removed the `isLocked` function in favor of `locked`, to extend the new proposal [IERC5192](https://github.com/attestate/ERC5192/blob/main/src/IERC5192.sol). As a consequence the interfaceId is changed from `0xd8e4c296` to `0x2e4e0d27`
 
 **0.2.0**
 - (breaking change) The upgradeable version is not extending UUPSUpgradeable anymore, leaving the developer to decide with proxy to use. This implies that whoever is using ERC721Lockable without importing UUPSUpgradeable, now has to import it explicitly.

--- a/contracts/ERC721Lockable.sol
+++ b/contracts/ERC721Lockable.sol
@@ -28,7 +28,7 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
     address to,
     uint256 tokenId
   ) internal override(ERC721, ERC721Enumerable) {
-    require(!isLocked(tokenId), "Token is locked");
+    require(!locked(tokenId), "Token is locked");
     super._beforeTokenTransfer(from, to, tokenId);
   }
 
@@ -36,7 +36,7 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
     return interfaceId == type(IERC721Lockable).interfaceId || super.supportsInterface(interfaceId);
   }
 
-  function isLocked(uint256 tokenId) public view virtual override returns (bool) {
+  function locked(uint256 tokenId) public view virtual override returns (bool) {
     return _lockedBy[tokenId] != address(0);
   }
 
@@ -64,7 +64,7 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
     uint256 balance = balanceOf(owner);
     for (uint256 i = 0; i < balance; i++) {
       uint256 id = tokenOfOwnerByIndex(owner, i);
-      if (isLocked(id)) {
+      if (locked(id)) {
         return true;
       }
     }
@@ -88,7 +88,7 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
 
   // emergency function in case a compromised locker is removed
   function unlockIfRemovedLocker(uint256 tokenId) external virtual override onlyOwner {
-    require(isLocked(tokenId), "Not a locked tokenId");
+    require(locked(tokenId), "Not a locked tokenId");
     require(!_locker[_lockedBy[tokenId]], "Locker is still active");
     delete _lockedBy[tokenId];
     emit ForcefullyUnlocked(tokenId);
@@ -97,12 +97,12 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
   // manage approval
 
   function approve(address to, uint256 tokenId) public virtual override {
-    require(!isLocked(tokenId), "Locked asset");
+    require(!locked(tokenId), "Locked asset");
     super.approve(to, tokenId);
   }
 
   function getApproved(uint256 tokenId) public view virtual override returns (address) {
-    if (isLocked(tokenId) && lockerOf(tokenId) != _msgSender()) {
+    if (locked(tokenId) && lockerOf(tokenId) != _msgSender()) {
       return address(0);
     }
     return super.getApproved(tokenId);

--- a/contracts/ERC721LockableUpgradeable.sol
+++ b/contracts/ERC721LockableUpgradeable.sol
@@ -47,7 +47,7 @@ contract ERC721LockableUpgradeable is
     address to,
     uint256 tokenId
   ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) {
-    require(!isLocked(tokenId), "Token is locked");
+    require(!locked(tokenId), "Token is locked");
     super._beforeTokenTransfer(from, to, tokenId);
   }
 
@@ -60,7 +60,7 @@ contract ERC721LockableUpgradeable is
     return interfaceId == type(IERC721Lockable).interfaceId || super.supportsInterface(interfaceId);
   }
 
-  function isLocked(uint256 tokenId) public view virtual override returns (bool) {
+  function locked(uint256 tokenId) public view virtual override returns (bool) {
     return _lockedBy[tokenId] != address(0);
   }
 
@@ -88,7 +88,7 @@ contract ERC721LockableUpgradeable is
     uint256 balance = balanceOf(owner);
     for (uint256 i = 0; i < balance; i++) {
       uint256 id = tokenOfOwnerByIndex(owner, i);
-      if (isLocked(id)) {
+      if (locked(id)) {
         return true;
       }
     }
@@ -112,7 +112,7 @@ contract ERC721LockableUpgradeable is
 
   // emergency function in case a compromised locker is removed
   function unlockIfRemovedLocker(uint256 tokenId) external virtual override onlyOwner {
-    require(isLocked(tokenId), "Not a locked tokenId");
+    require(locked(tokenId), "Not a locked tokenId");
     require(!_locker[_lockedBy[tokenId]], "Locker is still active");
     delete _lockedBy[tokenId];
     emit ForcefullyUnlocked(tokenId);
@@ -121,12 +121,12 @@ contract ERC721LockableUpgradeable is
   // manage approval
 
   function approve(address to, uint256 tokenId) public virtual override {
-    require(!isLocked(tokenId), "Locked asset");
+    require(!locked(tokenId), "Locked asset");
     super.approve(to, tokenId);
   }
 
   function getApproved(uint256 tokenId) public view virtual override returns (address) {
-    if (isLocked(tokenId) && lockerOf(tokenId) != _msgSender()) {
+    if (locked(tokenId) && lockerOf(tokenId) != _msgSender()) {
       return address(0);
     }
     return super.getApproved(tokenId);

--- a/contracts/IERC5192.sol
+++ b/contracts/IERC5192.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+// Author: Tim Daubenschütz (tim@daubenschuetz.de)
+// Repo: https://github.com/attestate/ERC5192/blob/main/src/IERC5192.sol
+
+interface IERC5192 {
+  /// @notice Emitted when the locking status is changed to locked.
+  /// @dev If a token is minted and the status is locked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Locked(uint256 tokenId);
+
+  /// @notice Emitted when the locking status is changed to unlocked.
+  /// @dev If a token is minted and the status is unlocked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Unlocked(uint256 tokenId);
+
+  /// @notice Returns the locking status of an Soulbound Token
+  /// @dev SBTs assigned to zero address are considered invalid, and queries
+  /// about them do throw.
+  /// @param tokenId The identifier for an SBT.
+  function locked(uint256 tokenId) external view returns (bool);
+}

--- a/contracts/IERC721Lockable.sol
+++ b/contracts/IERC721Lockable.sol
@@ -4,16 +4,16 @@ pragma solidity ^0.8.0;
 // Author:
 // Francesco Sullo <francesco@sullo.co>
 
-// ERC165 interface id is 0xd8e4c296
-interface IERC721Lockable {
+import "./IERC5192.sol";
+
+// ERC165 interface id is 0x2e4e0d27
+interface IERC721Lockable is IERC5192 {
   event LockerSet(address locker);
   event LockerRemoved(address locker);
   event ForcefullyUnlocked(uint256 tokenId);
-  event Locked(uint256 tokendId);
-  event Unlocked(uint256 tokendId);
 
-  // tells if a token is locked
-  function isLocked(uint256 tokenID) external view returns (bool);
+  // tells if a token is locked. Removed to extend IERC5192
+  // function locked(uint256 tokenID) external view returns (bool);
 
   // tells the address of the contract which is locking a token
   function lockerOf(uint256 tokenID) external view returns (address);

--- a/contracts/mocks/ERC721LockableUpgradeableMock.sol
+++ b/contracts/mocks/ERC721LockableUpgradeableMock.sol
@@ -17,4 +17,8 @@ contract ERC721LockableUpgradeableMock is ERC721LockableUpgradeable, UUPSUpgrade
   }
 
   function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
+
+  function getInterfaceId() public pure returns (bytes4) {
+    return type(IERC721Lockable).interfaceId;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/erc721lockable",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"

--- a/test/Lockable.test.js
+++ b/test/Lockable.test.js
@@ -19,7 +19,9 @@ describe("ERC721Lockable", function () {
 
   it("should verify the flow", async function () {
 
-    expect(await myToken.supportsInterface("0xd8e4c296")).equal(true)
+    console.log(await myToken.getInterfaceId());
+
+    expect(await myToken.supportsInterface("0x2e4e0d27")).equal(true)
 
   });
 


### PR DESCRIPTION
BREAKING CHANGE 
Extending [IERC5192](https://github.com/attestate/ERC5192/blob/main/src/IERC5192.sol), the function `isLocked` has been renamed `locked` changing the interfaceId from `0xd8e4c296` to `0x2e4e0d27`.