### PR TITLE
Change modifier

### DIFF
--- a/contracts/ERC721Lockable.sol
+++ b/contracts/ERC721Lockable.sol
@@ -90,7 +90,7 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
   function unlockIfRemovedLocker(uint256 tokenId) external virtual override {
     require(locked(tokenId), "Not a locked tokenId");
     require(!_locker[_lockedBy[tokenId]], "Locker is still active");
-    require(ownerOf(tokenId) == _msgSender() || owner() == _msgSender(), "Forbidden");
+    require(ownerOf(tokenId) == _msgSender(), "Not the asset owner");
     delete _lockedBy[tokenId];
     emit ForcefullyUnlocked(tokenId);
   }

--- a/contracts/ERC721Lockable.sol
+++ b/contracts/ERC721Lockable.sol
@@ -87,9 +87,10 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
   }
 
   // emergency function in case a compromised locker is removed
-  function unlockIfRemovedLocker(uint256 tokenId) external virtual override onlyOwner {
+  function unlockIfRemovedLocker(uint256 tokenId) external virtual override {
     require(locked(tokenId), "Not a locked tokenId");
     require(!_locker[_lockedBy[tokenId]], "Locker is still active");
+    require(ownerOf(tokenId) == _msgSender() || owner() == _msgSender(), "Forbidden");
     delete _lockedBy[tokenId];
     emit ForcefullyUnlocked(tokenId);
   }


### PR DESCRIPTION
Initially the function `unlockIfRemovedLocker` was callable only by the contract's owner. With this change it can be called by the token owner, who may have a reason to keep it locked anyway.