### PR TITLE
Adding missed interfaces in supportsInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ interface IERC721Lockable is IERC5192 {
 
 ```
 
-the apparently missing events and functions are inherited from IERC721
+the apparently missing events and functions are inherited from IERC5192
 ``` solidity
 interface IERC5192 {
   event Locked(uint256 tokenId);

--- a/contracts/ERC721Lockable.sol
+++ b/contracts/ERC721Lockable.sol
@@ -33,7 +33,10 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
   }
 
   function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
-    return interfaceId == type(IERC721Lockable).interfaceId || super.supportsInterface(interfaceId);
+    return
+      interfaceId == type(IERC5192).interfaceId ||
+      interfaceId == type(IERC721Lockable).interfaceId ||
+      super.supportsInterface(interfaceId);
   }
 
   function locked(uint256 tokenId) public view virtual override returns (bool) {

--- a/contracts/ERC721LockableUpgradeable.sol
+++ b/contracts/ERC721LockableUpgradeable.sol
@@ -57,7 +57,10 @@ contract ERC721LockableUpgradeable is
     override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
     returns (bool)
   {
-    return interfaceId == type(IERC721Lockable).interfaceId || super.supportsInterface(interfaceId);
+    return
+      interfaceId == type(IERC5192).interfaceId ||
+      interfaceId == type(IERC721Lockable).interfaceId ||
+      super.supportsInterface(interfaceId);
   }
 
   function locked(uint256 tokenId) public view virtual override returns (bool) {


### PR DESCRIPTION
Adding missing interface `IERC5192` in `supportsInterface`.