### PR TITLE
Aligning behaviour of `locked()` to IERC5192

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Feel free to make a PR to add your implementation.
 
 ## History
 
-**0.4.0**
+**0.4.0** / breaking
 - align `locked` to [IERC5192](https://eips.ethereum.org/EIPS/eip-5192) that specifies that it should revert if owner is address(0), i.e., if the token does not exist
 
 **0.3.0**

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Feel free to make a PR to add your implementation.
 
 ## History
 
+**0.4.0**
+- align `locked` to [IERC5192](https://eips.ethereum.org/EIPS/eip-5192) that specifies that it should revert if owner is address(0), i.e., if the token does not exist
+
 **0.3.0**
 - (breaking) removed the `isLocked` function in favor of `locked`, to extend the new proposal [IERC5192](https://github.com/attestate/ERC5192/blob/main/src/IERC5192.sol). As a consequence the interfaceId is changed from `0xd8e4c296` to `0x2e4e0d27`
 

--- a/contracts/ERC721Lockable.sol
+++ b/contracts/ERC721Lockable.sol
@@ -28,7 +28,13 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
     address to,
     uint256 tokenId
   ) internal override(ERC721, ERC721Enumerable) {
-    require(!locked(tokenId), "Token is locked");
+    require(
+      // during minting
+      from == address(0) ||
+        // later
+        !locked(tokenId),
+      "Token is locked"
+    );
     super._beforeTokenTransfer(from, to, tokenId);
   }
 
@@ -40,6 +46,7 @@ contract ERC721Lockable is IERC721Lockable, Ownable, ERC721, ERC721Enumerable {
   }
 
   function locked(uint256 tokenId) public view virtual override returns (bool) {
+    require(_exists(tokenId), "Token does not exist");
     return _lockedBy[tokenId] != address(0);
   }
 

--- a/contracts/ERC721LockableUpgradeable.sol
+++ b/contracts/ERC721LockableUpgradeable.sol
@@ -47,7 +47,13 @@ contract ERC721LockableUpgradeable is
     address to,
     uint256 tokenId
   ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) {
-    require(!locked(tokenId), "Token is locked");
+    require(
+      // during minting
+      from == address(0) ||
+        // later
+        !locked(tokenId),
+      "Token is locked"
+    );
     super._beforeTokenTransfer(from, to, tokenId);
   }
 
@@ -64,6 +70,7 @@ contract ERC721LockableUpgradeable is
   }
 
   function locked(uint256 tokenId) public view virtual override returns (bool) {
+    require(_exists(tokenId), "Token does not exist");
     return _lockedBy[tokenId] != address(0);
   }
 
@@ -121,7 +128,7 @@ contract ERC721LockableUpgradeable is
     emit ForcefullyUnlocked(tokenId);
   }
 
-  // manage approval
+  // overrides approval
 
   function approve(address to, uint256 tokenId) public virtual override {
     require(!locked(tokenId), "Locked asset");

--- a/contracts/mocks/ERC721LockableUpgradeableMock.sol
+++ b/contracts/mocks/ERC721LockableUpgradeableMock.sol
@@ -9,6 +9,8 @@ import "../ERC721LockableUpgradeable.sol";
 //import "hardhat/console.sol";
 
 contract ERC721LockableUpgradeableMock is ERC721LockableUpgradeable, UUPSUpgradeable {
+
+  uint public latestTokenId;
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() initializer {}
 
@@ -20,5 +22,12 @@ contract ERC721LockableUpgradeableMock is ERC721LockableUpgradeable, UUPSUpgrade
 
   function getInterfaceId() public pure returns (bytes4) {
     return type(IERC721Lockable).interfaceId;
+  }
+
+  function mint (address to, uint256 amount) public {
+    for (uint256 i = 0; i < amount; i++) {
+      // inefficient, but this is a mock :-)
+      _safeMint(to, ++latestTokenId);
+    }
   }
 }

--- a/contracts/mocks/MyLocker.sol
+++ b/contracts/mocks/MyLocker.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+// Authors: Francesco Sullo <francesco@sullo.co>
+
+import "../IERC721Lockable.sol";
+
+contract MyLocker {
+
+  function lock(address asset, uint id) public {
+    IERC721Lockable(asset).lock(id);
+  }
+
+  function unlock(address asset, uint id) public {
+    IERC721Lockable(asset).unlock(id);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/erc721lockable",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Aligning behavior of `locked()` to IERC5192 making it revert if the token does not exist, instead of returning false.
Added simple integration testing.